### PR TITLE
Fix assignment of property mac_address

### DIFF
--- a/custom_components/panasonic_hc/config_flow.py
+++ b/custom_components/panasonic_hc/config_flow.py
@@ -38,9 +38,9 @@ class PanasonicHCConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
-        mac_address = format_mac(user_input[CONF_MAC])
+        self.mac_address = format_mac(user_input[CONF_MAC])
 
-        if not validate_mac(mac_address):
+        if not validate_mac(self.mac_address):
             errors[CONF_MAC] = "invalid_mac_address"
             return self.async_show_form(
                 step_id="user",
@@ -48,7 +48,7 @@ class PanasonicHCConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
-        await self.async_set_unique_id(mac_address)
+        await self.async_set_unique_id(self.mac_address)
         self._abort_if_unique_id_configured(updates=user_input)
 
         return self.async_create_entry(


### PR DESCRIPTION
Hey men, I was trying your integration and I came up with the following error when you have to introduce the MAC address in the integration config form:

``` 
# HA Core logs
  File "/config/custom_components/panasonic_hc/config_flow.py", line 55, in async_step_user
    title=f"{MODEL}_{self.mac_address[-8:].replace(':','')}", data={}
                     ^^^^^^^^^^^^^^^^
AttributeError: 'PanasonicHCConfigFlow' object has no attribute 'mac_address'
```

I want to thank you for this awesome integration since in the past I tried to reverse-engineer the commands that are sent/received from the A/C unit and I was unable to fully understand how it works to make an integration for HA.

That being said, I hope you continue to improve the integration adding more features and fixing some bugs on the way.
